### PR TITLE
utils.ts: fix finding constructors when a comment exists

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -397,7 +397,6 @@ export function isEntryAContructor(
             line = line.trim();
             if (line.startsWith("//")) {
                 // Ignore single-line comment.
-                continue;
             } else if (line.includes("#[constructor]")) {
                 // Check if next line is contains entry type name
                 const nextLine = lines[index + 1];


### PR DESCRIPTION
constructors aren't found correctly if a comment exists before it.