### PR TITLE
types/index.ts: dont pass abi path for cairo 1.0 contract calls

### DIFF
--- a/src/starknet-wrappers.ts
+++ b/src/starknet-wrappers.ts
@@ -44,7 +44,7 @@ interface InteractWrapperOptions {
     nonce: string;
     choice: InteractChoice;
     address: string;
-    abi: string;
+    abi?: string;
     functionName: string;
     inputs?: string[];
     signature?: string[];
@@ -219,8 +219,6 @@ export abstract class StarknetWrapper {
     protected prepareInteractOptions(options: InteractWrapperOptions): string[] {
         const prepared = [
             ...options.choice.cliCommand,
-            "--abi",
-            options.abi,
             "--feeder_gateway_url",
             this.gatewayUrl,
             "--gateway_url",
@@ -230,6 +228,10 @@ export abstract class StarknetWrapper {
             "--address",
             options.address
         ];
+
+        if (options.abi) {
+            prepared.push("--abi", options.abi);
+        }
 
         if (options.inputs && options.inputs.length) {
             prepared.push("--inputs", ...options.inputs);
@@ -546,9 +548,11 @@ export class DockerWrapper extends StarknetWrapper {
     }
 
     public async interact(options: InteractWrapperOptions): Promise<ProcessResult> {
-        const binds: String2String = {
-            [options.abi]: options.abi
-        };
+        const binds: String2String = {};
+
+        if (options.abi) {
+            binds[options.abi] = options.abi;
+        }
 
         if (options.accountDir) {
             binds[options.accountDir] = options.accountDir;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -512,10 +512,16 @@ export class StarknetContract {
         }
 
         const adaptedInput = this.adaptInput(functionName, args);
+
+        // omit cairo 1.0 ABIs as it's not supported by the cairo-lang parser.
+        const abi =
+            this.abiPath && !fs.readFileSync(this.abiPath, "utf8").includes("core::")
+                ? this.abiPath
+                : undefined;
         const executed = await this.hre.starknetWrapper.interact({
             choice,
             address: this.address,
-            abi: this.abiPath,
+            abi,
             functionName: functionName,
             inputs: adaptedInput,
             signature: handleSignature(options.signature),


### PR DESCRIPTION
## Usage related changes

passing a cairo 1.0 abi to `starknet call` invocations result in a parser error as it's not supported, eg

```
Error: ParserError: :1:5: Unexpected token Token('COLON', ':'). Expected one of: "*", ".", end of input.
core::felt252
```

omit the abi parameter for cairo 1.0 abi's.

- Closes #347 


## Checklist:

-   [x] Formatted the code
-   [x] No linter errors + tried to avoid introducing linter warnings
-   [x] Performed a self-review of the code
-   [x] Rebased to the last commit of the target branch (or merged it into my branch)
-   [ ] Documented the changes
-   [ ] Updated the `test` directory (with a test case consisting of `network.json`, `hardhat.config.ts`, `check.ts`)
-   [x] Linked issues which this PR resolves
-   [ ] Created a PR to the `plugin` branch of [`starknet-hardhat-example`](https://github.com/0xSpaceShard/starknet-hardhat-example):
    -   < EXAMPLE_REPO_PR_URL > <!-- paste here if applicable -->
    -   [ ] Modified `test.sh` to use my example repo branch
    -   [ ] Restored `test.sh` to to use the original branch (after the example repo PR has been merged)
-   [ ] All tests are passing (for external contributors who don't have access to the CI/CD pipeline)
