### PR TITLE
Constructor detection via case file

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -390,6 +390,8 @@ export class StarknetContractFactory {
             throw new StarknetPluginError(msg);
         }
 
+        // Con be simplified once starkware fixes miltiple constructor issue.
+        // Precomputed selector can be used if only 'constructor' name allowed
         const selector = casmJson.entry_points_by_type.CONSTRUCTOR[0].selector;
         return (abiEntry: starknet.AbiEntry): boolean => {
             return hash.getSelectorFromName(abiEntry.name) === selector;


### PR DESCRIPTION
## Usage related changes

<!-- How the changes from this PR affect users. -->

-   No changes for user.

## Development related changes

<!-- How these changes affect the developers of this project - e.g. changes in testing or CI/CD. -->

-   Removed file parsing on every new entry.
-   Common function for finding constructor
-   Verifying correctness of casm file
## Checklist:

-   [x] Formatted the code
-   [x] No linter errors + tried to avoid introducing linter warnings
-   [x] Performed a self-review of the code
-   [x] Rebased to the last commit of the target branch (or merged it into my branch)
-   [x] Documented the changes
-   [ ] Updated the `test` directory (with a test case consisting of `network.json`, `hardhat.config.ts`, `check.ts`)
-   [ ] Linked issues which this PR resolves
-   [ ] Created a PR to the `plugin` branch of [`starknet-hardhat-example`](https://github.com/0xSpaceShard/starknet-hardhat-example):
    -   < EXAMPLE_REPO_PR_URL > <!-- paste here if applicable -->
    -   [ ] Modified `test.sh` to use my example repo branch
    -   [ ] Restored `test.sh` to to use the original branch (after the example repo PR has been merged)
-   [ ] All tests are passing (for external contributors who don't have access to the CI/CD pipeline)
