### PR TITLE
fix reading cairo 1.0 input specs

### DIFF
--- a/src/starknet-types.ts
+++ b/src/starknet-types.ts
@@ -29,7 +29,8 @@ export interface CairoFunction {
 }
 
 export interface EventSpecification {
-    data: Argument[];
+    data?: Argument[];
+    inputs?: Argument[];
     keys: string[];
     name: string;
     type: "event";

--- a/src/starknet-types.ts
+++ b/src/starknet-types.ts
@@ -29,8 +29,8 @@ export interface CairoFunction {
 }
 
 export interface EventSpecification {
-    data?: Argument[];
-    inputs?: Argument[];
+    data?: Argument[]; // cairo 0
+    inputs?: Argument[]; // cairo 1
     keys: string[];
     name: string;
     type: "event";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -762,7 +762,8 @@ export class StarknetContract {
                 throw new StarknetPluginError(msg);
             }
 
-            const adapted = adaptOutputUtil(rawEventData, eventSpecification.data, this.abi);
+            const inputSpecs = this.isCairo1 ? eventSpecification.inputs : eventSpecification.data;
+            const adapted = adaptOutputUtil(rawEventData, inputSpecs, this.abi);
             decodedEvents.push({ name: eventSpecification.name, data: adapted });
         }
 


### PR DESCRIPTION
## Usage related changes

cairo 1.0 events in the ABI have arguments listed under `inputs` instead of `data`: https://github.com/starkware-libs/cairo/blob/05867c82de42d5ee5cfa953dcca1cb826402f74b/crates/cairo-lang-starknet/src/abi_test.rs#L155

## Checklist:

-   [x] Formatted the code
-   [x] No linter errors + tried to avoid introducing linter warnings
-   [x] Performed a self-review of the code
-   [x] Rebased to the last commit of the target branch (or merged it into my branch)
-   [ ] Documented the changes
-   [ ] Updated the `test` directory (with a test case consisting of `network.json`, `hardhat.config.ts`, `check.ts`)
-   [ ] Linked issues which this PR resolves
-   [ ] Created a PR to the `plugin` branch of [`starknet-hardhat-example`](https://github.com/0xSpaceShard/starknet-hardhat-example):
    -   < EXAMPLE_REPO_PR_URL > <!-- paste here if applicable -->
    -   [ ] Modified `test.sh` to use my example repo branch
    -   [ ] Restored `test.sh` to to use the original branch (after the example repo PR has been merged)
-   [ ] All tests are passing (for external contributors who don't have access to the CI/CD pipeline)
