### PR TITLE
adapt.ts: fix core::integer::u32

### DIFF
--- a/src/adapt.ts
+++ b/src/adapt.ts
@@ -10,7 +10,7 @@ const COMMON_NUMERIC_TYPES = [
     "core::felt252",
     "core::integer::u8",
     "core::integer::u16",
-    "core::integer::u38",
+    "core::integer::u32",
     "core::integer::u64",
     "core::integer::u128",
     "core::integer::u256",


### PR DESCRIPTION
## Usage related changes

should be `u32` instead of `u38`

## Checklist:

-   [x] Formatted the code
-   [x] No linter errors + tried to avoid introducing linter warnings
-   [x] Performed a self-review of the code
-   [x] Rebased to the last commit of the target branch (or merged it into my branch)
-   [ ] Documented the changes
-   [ ] Updated the `test` directory (with a test case consisting of `network.json`, `hardhat.config.ts`, `check.ts`)
-   [ ] Linked issues which this PR resolves
-   [ ] Created a PR to the `plugin` branch of [`starknet-hardhat-example`](https://github.com/0xSpaceShard/starknet-hardhat-example):
    -   < EXAMPLE_REPO_PR_URL > <!-- paste here if applicable -->
    -   [ ] Modified `test.sh` to use my example repo branch
    -   [ ] Restored `test.sh` to to use the original branch (after the example repo PR has been merged)
-   [ ] All tests are passing (for external contributors who don't have access to the CI/CD pipeline)
