### PR TITLE
Add support for class_hash::ClassHash

### DIFF
--- a/src/adapt.ts
+++ b/src/adapt.ts
@@ -13,7 +13,8 @@ const COMMON_NUMERIC_TYPES = [
     "core::integer::u32",
     "core::integer::u64",
     "core::integer::u128",
-    "core::starknet::contract_address::ContractAddress"
+    "core::starknet::contract_address::ContractAddress",
+    "core::starknet::class_hash::ClassHash"
 ];
 
 const ARRAY_TYPE_PREFIX = "core::array::Array::<";


### PR DESCRIPTION
## Usage related changes

<!-- How the changes from this PR affect users. -->

-   Adds support for calling/invoking contracts that have type core::starknet::class_hash::ClasHash in abi of function. It is a pedersen hash just like ContractAddress so they should be parsed similarly.

## Development related changes

None

## Checklist:

-   [x] Formatted the code
-   [x] No linter errors + tried to avoid introducing linter warnings
-   [x] Performed a self-review of the code
-   [x] Rebased to the last commit of the target branch (or merged it into my branch)
-   [ ] Documented the changes
-   [ ] Updated the `test` directory (with a test case consisting of `network.json`, `hardhat.config.ts`, `check.ts`)
-   [ ] Linked issues which this PR resolves
-   [ ] Created a PR to the `plugin` branch of [`starknet-hardhat-example`](https://github.com/0xSpaceShard/starknet-hardhat-example):
    -   < EXAMPLE_REPO_PR_URL > <!-- paste here if applicable -->
    -   [ ] Modified `test.sh` to use my example repo branch
    -   [ ] Restored `test.sh` to to use the original branch (after the example repo PR has been merged)
-   [ ] All tests are passing (for external contributors who don't have access to the CI/CD pipeline)
