### PR TITLE
Support eth address

### DIFF
--- a/src/adapt.ts
+++ b/src/adapt.ts
@@ -210,8 +210,9 @@ export function adaptInputUtil(
     // Initialize an array with the user input
     const inputLen = Object.keys(input || {}).length;
     if (expectedInputCount != inputLen) {
-        const msg = `${functionName}: Expected ${expectedInputCount} argument${expectedInputCount === 1 ? "" : "s"
-            }, got ${inputLen}.`;
+        const msg = `${functionName}: Expected ${expectedInputCount} argument${
+            expectedInputCount === 1 ? "" : "s"
+        }, got ${inputLen}.`;
         throw new StarknetPluginError(msg);
     }
 
@@ -347,8 +348,9 @@ function adaptComplexInput(
             // Initialize an array with the user input
             const inputLen = Object.keys(input || {}).length;
             if (inputLen !== memberTypes.length) {
-                const msg = `"${inputSpec.name}": Expected ${memberTypes.length} member${memberTypes.length === 1 ? "" : "s"
-                    }, got ${inputLen}.`;
+                const msg = `"${inputSpec.name}": Expected ${memberTypes.length} member${
+                    memberTypes.length === 1 ? "" : "s"
+                }, got ${inputLen}.`;
                 throw new StarknetPluginError(msg);
             }
 
@@ -364,8 +366,9 @@ function adaptComplexInput(
             }
 
             if (input.length != memberTypes.length) {
-                const msg = `"${inputSpec.name}": Expected ${memberTypes.length} member${memberTypes.length === 1 ? "" : "s"
-                    }, got ${input.length}.`;
+                const msg = `"${inputSpec.name}": Expected ${memberTypes.length} member${
+                    memberTypes.length === 1 ? "" : "s"
+                }, got ${input.length}.`;
                 throw new StarknetPluginError(msg);
             }
 
@@ -410,8 +413,9 @@ function adaptStructInput(
     const inputLen = Object.keys(input || {}).length;
 
     if (expectedInputCount != inputLen) {
-        const msg = `"${inputSpec.name}": Expected ${expectedInputCount} member${expectedInputCount === 1 ? "" : "s"
-            }, got ${inputLen}.`;
+        const msg = `"${inputSpec.name}": Expected ${expectedInputCount} member${
+            expectedInputCount === 1 ? "" : "s"
+        }, got ${inputLen}.`;
         throw new StarknetPluginError(msg);
     }
 

--- a/src/adapt.ts
+++ b/src/adapt.ts
@@ -14,7 +14,8 @@ const COMMON_NUMERIC_TYPES = [
     "core::integer::u64",
     "core::integer::u128",
     "core::starknet::contract_address::ContractAddress",
-    "core::starknet::class_hash::ClassHash"
+    "core::starknet::class_hash::ClassHash",
+    "core::starknet::eth_address::EthAddress"
 ];
 
 const ARRAY_TYPE_PREFIX = "core::array::Array::<";
@@ -209,9 +210,8 @@ export function adaptInputUtil(
     // Initialize an array with the user input
     const inputLen = Object.keys(input || {}).length;
     if (expectedInputCount != inputLen) {
-        const msg = `${functionName}: Expected ${expectedInputCount} argument${
-            expectedInputCount === 1 ? "" : "s"
-        }, got ${inputLen}.`;
+        const msg = `${functionName}: Expected ${expectedInputCount} argument${expectedInputCount === 1 ? "" : "s"
+            }, got ${inputLen}.`;
         throw new StarknetPluginError(msg);
     }
 
@@ -347,9 +347,8 @@ function adaptComplexInput(
             // Initialize an array with the user input
             const inputLen = Object.keys(input || {}).length;
             if (inputLen !== memberTypes.length) {
-                const msg = `"${inputSpec.name}": Expected ${memberTypes.length} member${
-                    memberTypes.length === 1 ? "" : "s"
-                }, got ${inputLen}.`;
+                const msg = `"${inputSpec.name}": Expected ${memberTypes.length} member${memberTypes.length === 1 ? "" : "s"
+                    }, got ${inputLen}.`;
                 throw new StarknetPluginError(msg);
             }
 
@@ -365,9 +364,8 @@ function adaptComplexInput(
             }
 
             if (input.length != memberTypes.length) {
-                const msg = `"${inputSpec.name}": Expected ${memberTypes.length} member${
-                    memberTypes.length === 1 ? "" : "s"
-                }, got ${input.length}.`;
+                const msg = `"${inputSpec.name}": Expected ${memberTypes.length} member${memberTypes.length === 1 ? "" : "s"
+                    }, got ${input.length}.`;
                 throw new StarknetPluginError(msg);
             }
 
@@ -412,9 +410,8 @@ function adaptStructInput(
     const inputLen = Object.keys(input || {}).length;
 
     if (expectedInputCount != inputLen) {
-        const msg = `"${inputSpec.name}": Expected ${expectedInputCount} member${
-            expectedInputCount === 1 ? "" : "s"
-        }, got ${inputLen}.`;
+        const msg = `"${inputSpec.name}": Expected ${expectedInputCount} member${expectedInputCount === 1 ? "" : "s"
+            }, got ${inputLen}.`;
         throw new StarknetPluginError(msg);
     }
 


### PR DESCRIPTION
## Usage related changes

- Support the recently introduced EthAddress type
- Partly address #341 

## Development related changes

- Format the code with `npm run format`

## Checklist:

-   [x] Formatted the code
-   [x] No linter errors + tried to avoid introducing linter warnings
-   [x] Performed a self-review of the code
-   [x] Rebased to the last commit of the target branch (or merged it into my branch)
-   [ ] Documented the changes
-   [ ] Updated the `test` directory (with a test case consisting of `network.json`, `hardhat.config.ts`, `check.ts`)
-   [ ] Linked issues which this PR resolves
-   [ ] Created a PR to the `plugin` branch of [`starknet-hardhat-example`](https://github.com/0xSpaceShard/starknet-hardhat-example):
    -   < EXAMPLE_REPO_PR_URL > <!-- paste here if applicable -->
    -   [ ] Modified `test.sh` to use my example repo branch
    -   [ ] Restored `test.sh` to to use the original branch (after the example repo PR has been merged)
-   [ ] All tests are passing (for external contributors who don't have access to the CI/CD pipeline)
