### PR TITLE
Refactor constructor checking

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -402,7 +402,7 @@ export class StarknetContractFactory {
 
         // Can be simplified once starkware fixes multiple constructor issue.
         // Precomputed selector can be used if only 'constructor' name allowed
-        const selector = constructors[0]?.selector;
+        const selector = constructors[0].selector;
         return (abiEntry: starknet.AbiEntry): boolean => {
             return hash.getSelectorFromName(abiEntry.name) === selector;
         };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -389,24 +389,25 @@ export class StarknetContractFactory {
             throw new StarknetPluginError(msg);
         }
 
-        if (!casmJson?.entry_points_by_type?.CONSTRUCTOR) {
-            const msg = "Invalid .CASM structure: No CONSTRUCTOR in entry_points_by_type";
-            throw new StarknetPluginError(msg);
+        const constructors = casmJson?.entry_points_by_type?.CONSTRUCTOR;
+        if (!constructors || constructors.length === 0) {
+            return () => false;
         }
 
         // Can be removed after new cairo release.
-        if (casmJson.entry_points_by_type.CONSTRUCTOR.length > 1) {
+        if (constructors.length > 1) {
             const msg = "There can be at most 1 constructor.";
             throw new StarknetPluginError(msg);
         }
 
         // Can be simplified once starkware fixes multiple constructor issue.
         // Precomputed selector can be used if only 'constructor' name allowed
-        const selector = casmJson.entry_points_by_type.CONSTRUCTOR[0]?.selector;
+        const selector = constructors[0]?.selector;
         return (abiEntry: starknet.AbiEntry): boolean => {
             return hash.getSelectorFromName(abiEntry.name) === selector;
         };
     }
+
     /**
      * Declare a contract class.
      * @param options optional arguments to class declaration


### PR DESCRIPTION
## Usage related changes

<!-- How the changes from this PR affect users. -->

-   N/A

## Development related changes

<!-- How these changes affect the developers of this project - e.g. changes in testing or CI/CD. -->

-  closes #367  Refactor of the resolveConstructorPredicate() function. If the CONSTRUCTOR property is not declared in .casm, or if the value is an empty array, it will no longer produce an error. Instead, the function will immediately return a boolean false.

## Checklist:

-   [X] Formatted the code
-   [X] No linter errors + tried to avoid introducing linter warnings
-   [X] Performed a self-review of the code
-   [X] Rebased to the last commit of the target branch (or merged it into my branch)
-   [ ] Documented the changes
-   [ ] Updated the `test` directory (with a test case consisting of `network.json`, `hardhat.config.ts`, `check.ts`)
-   [ ] Linked issues which this PR resolves
-   [ ] Created a PR to the `plugin` branch of [`starknet-hardhat-example`](https://github.com/0xSpaceShard/starknet-hardhat-example):
    -   < EXAMPLE_REPO_PR_URL > <!-- paste here if applicable -->
    -   [ ] Modified `test.sh` to use my example repo branch
    -   [ ] Restored `test.sh` to to use the original branch (after the example repo PR has been merged)
-   [ ] All tests are passing (for external contributors who don't have access to the CI/CD pipeline)
