### PR TITLE
Fix payload type

### DIFF
--- a/src/devnet-utils.ts
+++ b/src/devnet-utils.ts
@@ -165,7 +165,7 @@ Make sure you really want to interact with Devnet and that it is running and ava
     public async consumeMessageFromL2(
         l2ContractAddress: string,
         l1ContractAddress: string,
-        payload: number[]
+        payload: Numeric[]
     ) {
         const body = {
             l2_contract_address: l2ContractAddress,

--- a/src/types/devnet.ts
+++ b/src/types/devnet.ts
@@ -61,13 +61,13 @@ export interface Devnet {
      * Sends a mock message from L2 to L1
      * @param {string} l2ContractAddress - Address of the L2 contract.
      * @param {string} l1ContractAddress - Address of the L1 contract.
-     * @param {Array<number>} payload - Payload to send to the L1 network.
+     * @param {Array<Numeric>} payload - Payload to send to the L1 network.
      * @returns Message hash
      */
     consumeMessageFromL2: (
         l2ContractAddress: string,
         l1ContractAddress: string,
-        payload: Array<number>
+        payload: Array<Numeric>
     ) => Promise<L2ToL1MockTxResponse>;
 
     /**


### PR DESCRIPTION
## Usage related changes

<!-- How the changes from this PR affect users. -->

-   `payload` type changed from `number` to `Numeric` for `consumeMessageFromL2` devnet function
## Development related changes

<!-- How these changes affect the developers of this project - e.g. changes in testing or CI/CD. -->

-   NA

## Checklist:

-   [x] Formatted the code
-   [x] No linter errors + tried to avoid introducing linter warnings
-   [x] Performed a self-review of the code
-   [x] Rebased to the last commit of the target branch (or merged it into my branch)
-   [ ] Updated the `test` directory (with a test case consisting of `network.json`, `hardhat.config.ts`, `check.ts`)
-   [ ] All tests are passing (for external contributors who don't have access to the CI/CD pipeline)
