### PR TITLE
Adapt to cairo-lang/starknet 0.11.1

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-    "CAIRO_LANG": "0.11.0.2",
-    "STARKNET_DEVNET": "0.5.0",
-    "CAIRO_COMPILER": "v1.0.0-alpha.6"
+    "CAIRO_LANG": "0.11.1.1",
+    "STARKNET_DEVNET": "0.5.1",
+    "CAIRO_COMPILER": "v1.0.0-rc0"
 }

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
     "CAIRO_LANG": "0.11.1.1",
-    "STARKNET_DEVNET": "0.5.1",
+    "STARKNET_DEVNET": "0.5.2",
     "CAIRO_COMPILER": "v1.0.0-rc0"
 }

--- a/scripts/setup-cairo1-compiler.sh
+++ b/scripts/setup-cairo1-compiler.sh
@@ -3,7 +3,7 @@
 set -eu
 
 if [ "$TEST_SUBDIR" == "configuration-tests" ]; then
-    CAIRO_1_COMPILER_TARGET_TAG="v1.0.0-alpha.6"
+    CAIRO_1_COMPILER_TARGET_TAG=$(jq -r .CAIRO_COMPILER config.json)
 
     echo "Installing cairo compiler $CAIRO_1_COMPILER_TARGET_TAG"
     # need rust to install cairo-rs-py

--- a/scripts/setup-config-test-dependencies.sh
+++ b/scripts/setup-config-test-dependencies.sh
@@ -6,7 +6,8 @@ if [ "$TEST_SUBDIR" == "configuration-tests" ]; then
     CAIRO_1_COMPILER_TARGET_TAG=$(jq -r .CAIRO_COMPILER config.json)
 
     echo "Installing cairo compiler $CAIRO_1_COMPILER_TARGET_TAG"
-    # need rust to install cairo-rs-py
+    # need rust to install cairo-rs-py dependency of devnet
+    # need rust to install cairo compiler
     if rustc --version; then
         echo "rustc installed"
     else
@@ -27,7 +28,7 @@ if [ "$TEST_SUBDIR" == "configuration-tests" ]; then
             --manifest-path cairo-compiler/Cargo.toml \
             --release
 
-        export CAIRO_1_COMPILER_DIR="cairo-compiler/target/release"
+        export CAIRO_1_COMPILER_DIR=$(realpath "cairo-compiler/target/release")
     fi
 
     $CAIRO_1_COMPILER_DIR/starknet-compile --version

--- a/scripts/test-dev.sh
+++ b/scripts/test-dev.sh
@@ -68,7 +68,7 @@ fi
 
 if [[ "y" == "$RUN_SETUP" ]]; then
     echo ""
-    source ./scripts/setup-cairo1-compiler.sh
+    source ./scripts/setup-config-test-dependencies.sh
     rm -rf starknet-hardhat-example
     git clone -b "${EXAMPLE_REPO_BRANCH:=plugin}" --single-branch https://github.com/0xSpaceShard/starknet-hardhat-example.git
     cd starknet-hardhat-example

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -6,8 +6,9 @@ if [[ -z "${STARKNET_HARDHAT_DEV:-}" ]]; then
     ./scripts/test-setup.sh
     ./scripts/install-devnet.sh
 fi
+source  ./scripts/setup-cairo1-compiler.sh
+
 cd ./starknet-hardhat-example
-source  ../scripts/setup-cairo1-compiler.sh
 
 total=0
 success=0

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -6,7 +6,7 @@ if [[ -z "${STARKNET_HARDHAT_DEV:-}" ]]; then
     ./scripts/test-setup.sh
     ./scripts/install-devnet.sh
 fi
-source ./scripts/setup-cairo1-compiler.sh
+source ./scripts/setup-config-test-dependencies.sh
 
 cd ./starknet-hardhat-example
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -6,7 +6,7 @@ if [[ -z "${STARKNET_HARDHAT_DEV:-}" ]]; then
     ./scripts/test-setup.sh
     ./scripts/install-devnet.sh
 fi
-source  ./scripts/setup-cairo1-compiler.sh
+source ./scripts/setup-cairo1-compiler.sh
 
 cd ./starknet-hardhat-example
 
@@ -23,8 +23,8 @@ fi
 
 function run_test() {
     test_case="$1"
-     network="$2"
-     test_name=$(basename $test_case)
+    network="$2"
+    test_name=$(basename $test_case)
 
     network_file="$test_case/network.json"
 


### PR DESCRIPTION
## Usage related changes

- Close #363
  - Default to cairo-lang 0.11.1.1 in dockerized mode
- Partly address #369
  - Using cairo v1.0.0-rc0
  - Not supporting imports
  - Not supporting config (toml) file
- Use devnet v0.5.2 (for testing and integrated-devnet)

## Development related changes

- Apply formatting in some bash files
- In setup-cairo1-compiler.sh, read compiler version from config.json
- Rename `scripts/setup-cairo1-compiler.sh` to `scripts/setup-config-test-dependencies.sh`

## Checklist:

-   [x] Formatted the code
-   [x] No linter errors + tried to avoid introducing linter warnings
-   [x] Performed a self-review of the code
-   [x] Rebased to the last commit of the target branch (or merged it into my branch)
-   [x] Documented the changes
-   [x] Updated the `test` directory (with a test case consisting of `network.json`, `hardhat.config.ts`, `check.ts`)
-   [x] Linked issues which this PR resolves
-   [x] All tests are passing (for external contributors who don't have access to the CI/CD pipeline)
