### PR TITLE
Replace internal Starknet CLI usage with starknet.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
                 "form-data": "^4.0.0",
                 "glob": "^10.0.0",
                 "shelljs": "^0.8.5",
-                "starknet": "^4.22.0"
+                "starknet": "~5.17.0"
             },
             "devDependencies": {
                 "@types/chai": "^4.3.0",
@@ -307,6 +307,7 @@
             "version": "5.7.0",
             "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.7.0.tgz",
             "integrity": "sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==",
+            "dev": true,
             "funding": [
                 {
                     "type": "individual",
@@ -480,6 +481,7 @@
             "version": "5.7.0",
             "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.7.0.tgz",
             "integrity": "sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==",
+            "dev": true,
             "funding": [
                 {
                     "type": "individual",
@@ -1029,10 +1031,36 @@
                 "node": ">=12.0.0"
             }
         },
+        "node_modules/@noble/curves": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.0.0.tgz",
+            "integrity": "sha512-2upgEu0iLiDVDZkNLeFV2+ht0BAVgQnEmCk6JsOch9Rp8xfkMCbvbAZlA2pBHQc73dbl+vFOXfqkf4uemdn0bw==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://paulmillr.com/funding/"
+                }
+            ],
+            "dependencies": {
+                "@noble/hashes": "1.3.0"
+            }
+        },
+        "node_modules/@noble/curves/node_modules/@noble/hashes": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.0.tgz",
+            "integrity": "sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://paulmillr.com/funding/"
+                }
+            ]
+        },
         "node_modules/@noble/hashes": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.2.0.tgz",
             "integrity": "sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==",
+            "dev": true,
             "funding": [
                 {
                     "type": "individual",
@@ -1044,6 +1072,7 @@
             "version": "1.7.1",
             "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
             "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==",
+            "dev": true,
             "funding": [
                 {
                     "type": "individual",
@@ -1754,6 +1783,7 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.1.tgz",
             "integrity": "sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA==",
+            "dev": true,
             "funding": [
                 {
                     "type": "individual",
@@ -1765,6 +1795,7 @@
             "version": "1.1.5",
             "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.1.5.tgz",
             "integrity": "sha512-XyNh1rB0SkEqd3tXcXMi+Xe1fvg+kUIcoRIEujP1Jgv7DqW2r9lg3Ah0NkFaCs9sTkQAQA8kw7xiRXzENi9Rtw==",
+            "dev": true,
             "funding": [
                 {
                     "type": "individual",
@@ -1781,6 +1812,7 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.1.1.tgz",
             "integrity": "sha512-t+wDck2rVkh65Hmv280fYdVdY25J9YeEUIgn2LG1WM6gxFkGzcksoDiUkWVpVp3Oex9xGC68JU2dSbUfwZ2jPg==",
+            "dev": true,
             "funding": [
                 {
                     "type": "individual",
@@ -2546,14 +2578,6 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/bignumber.js": {
-            "version": "9.1.1",
-            "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.1.tgz",
-            "integrity": "sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig==",
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/binary-extensions": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -2581,7 +2605,8 @@
         "node_modules/bn.js": {
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
-            "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
+            "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
+            "dev": true
         },
         "node_modules/boolify": {
             "version": "1.0.1",
@@ -2613,7 +2638,8 @@
         "node_modules/brorand": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-            "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
+            "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
+            "dev": true
         },
         "node_modules/browser-level": {
             "version": "1.0.1",
@@ -3319,6 +3345,7 @@
             "version": "6.5.4",
             "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
             "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+            "dev": true,
             "dependencies": {
                 "bn.js": "^4.11.9",
                 "brorand": "^1.1.0",
@@ -3332,7 +3359,8 @@
         "node_modules/elliptic/node_modules/bn.js": {
             "version": "4.12.0",
             "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-            "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+            "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+            "dev": true
         },
         "node_modules/emoji-regex": {
             "version": "9.2.2",
@@ -3577,6 +3605,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-1.2.0.tgz",
             "integrity": "sha512-6yFQC9b5ug6/17CQpCyE3k9eKBMdhyVjzUy1WkiuY/E4vj/SXDBbCw8QEIaXqf0Mf2SnY6RmpDcwlUmBSS0EJw==",
+            "dev": true,
             "dependencies": {
                 "@noble/hashes": "1.2.0",
                 "@noble/secp256k1": "1.7.1",
@@ -4455,6 +4484,7 @@
             "version": "1.1.7",
             "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
             "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+            "dev": true,
             "dependencies": {
                 "inherits": "^2.0.3",
                 "minimalistic-assert": "^1.0.1"
@@ -4473,6 +4503,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
             "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+            "dev": true,
             "dependencies": {
                 "hash.js": "^1.0.3",
                 "minimalistic-assert": "^1.0.0",
@@ -4808,14 +4839,6 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
-        "node_modules/json-bigint": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
-            "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
-            "dependencies": {
-                "bignumber.js": "^9.0.0"
-            }
-        },
         "node_modules/json-schema-traverse": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -5085,6 +5108,11 @@
                 "node": ">=0.8.0"
             }
         },
+        "node_modules/lossless-json": {
+            "version": "2.0.9",
+            "resolved": "https://registry.npmjs.org/lossless-json/-/lossless-json-2.0.9.tgz",
+            "integrity": "sha512-PUfJ5foxULG1x/dXpSckmt0woBDqyq/WFoI885vEqjGwuP41K2EBYh2IT3zYx9dWqcTLIfXiCE5AjhF1jk9Sbg=="
+        },
         "node_modules/loupe": {
             "version": "2.3.6",
             "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
@@ -5185,6 +5213,32 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/micro-starknet": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/micro-starknet/-/micro-starknet-0.2.3.tgz",
+            "integrity": "sha512-6XBcC+GerlwJSR4iA0VaeXtS2wrayWFcA4PEzrJPMuFmWCaUtuGIq5K/DB5F/XgnL54/zl2Bxo690Lj7mYVA8A==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://paulmillr.com/funding/"
+                }
+            ],
+            "dependencies": {
+                "@noble/curves": "~1.0.0",
+                "@noble/hashes": "~1.3.0"
+            }
+        },
+        "node_modules/micro-starknet/node_modules/@noble/hashes": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.1.tgz",
+            "integrity": "sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA==",
+            "engines": {
+                "node": ">= 16"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
         "node_modules/micromatch": {
             "version": "4.0.5",
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
@@ -5220,12 +5274,14 @@
         "node_modules/minimalistic-assert": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-            "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+            "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+            "dev": true
         },
         "node_modules/minimalistic-crypto-utils": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-            "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="
+            "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
+            "dev": true
         },
         "node_modules/minimatch": {
             "version": "3.1.2",
@@ -6712,20 +6768,15 @@
             }
         },
         "node_modules/starknet": {
-            "version": "4.22.0",
-            "resolved": "https://registry.npmjs.org/starknet/-/starknet-4.22.0.tgz",
-            "integrity": "sha512-jC9Taxb6a/ht9zmS1LU/DSLfwJKpgCJnE9AktVksc5SE/+jQMpqxsq6fm7PRiqupjiqRC1DOS8N47cj+KaGv4Q==",
+            "version": "5.17.0",
+            "resolved": "https://registry.npmjs.org/starknet/-/starknet-5.17.0.tgz",
+            "integrity": "sha512-gvIgk63Le0QQ20mU5RVcckz0BLjnVG5Q1SWbapErAlWVY2xknpWnrNXIcCYYh0c6eKG0+ogirLyNqm40+U6yHg==",
             "dependencies": {
-                "@ethersproject/bytes": "^5.6.1",
-                "bn.js": "^5.2.1",
-                "elliptic": "^6.5.4",
-                "ethereum-cryptography": "^1.0.3",
-                "hash.js": "^1.1.7",
+                "@noble/curves": "~1.0.0",
                 "isomorphic-fetch": "^3.0.0",
-                "json-bigint": "^1.0.0",
-                "minimalistic-assert": "^1.0.1",
+                "lossless-json": "^2.0.8",
+                "micro-starknet": "~0.2.1",
                 "pako": "^2.0.4",
-                "ts-custom-error": "^3.3.1",
                 "url-join": "^4.0.1"
             }
         },
@@ -6972,14 +7023,6 @@
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
             "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-        },
-        "node_modules/ts-custom-error": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/ts-custom-error/-/ts-custom-error-3.3.1.tgz",
-            "integrity": "sha512-5OX1tzOjxWEgsr/YEUWSuPrQ00deKLh6D7OTWcvNHm12/7QPyRh8SYpyWvA4IZv8H/+GQWQEh/kwo95Q9OVW1A==",
-            "engines": {
-                "node": ">=14.0.0"
-            }
         },
         "node_modules/ts-node": {
             "version": "10.9.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "form-data": "^4.0.0",
         "glob": "^10.0.0",
         "shelljs": "^0.8.5",
-        "starknet": "^4.22.0"
+        "starknet": "~5.17.0"
     },
     "peerDependencies": {
         "hardhat": "^2.14.0"

--- a/src/account-utils.ts
+++ b/src/account-utils.ts
@@ -1,10 +1,8 @@
 import axios, { AxiosError } from "axios";
-import crypto from "crypto";
-import { ec } from "elliptic";
 import fs from "fs";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import path from "path";
-import { ec as ellipticCurve, hash, number } from "starknet";
+import { ec, hash, stark } from "starknet";
 
 import {
     ABI_SUFFIX,
@@ -34,31 +32,15 @@ export type CallParameters = {
 type KeysType = {
     publicKey: string;
     privateKey: string;
-    keyPair: ec.KeyPair;
 };
 
-/*
- * Helper cryptography functions for Key generation and message signing
- */
-
-export function generateRandomStarkPrivateKey(length = 63) {
-    const characters = "0123456789ABCDEF";
-    let result = "";
-    for (let i = 0; i < length; ++i) {
-        result += characters.charAt(crypto.randomInt(characters.length));
-    }
-    return number.toBN(result, "hex");
-}
-
-export function signMultiCall(
-    publicKey: string,
-    keyPair: ec.KeyPair,
-    messageHash: string
-): bigint[] {
+export function signMultiCall(messageHash: string, privateKey: string): bigint[] {
+    const publicKey = ec.starkCurve.getStarkKey(privateKey);
     if (publicKey === "0x0") {
         return [BigInt(0), BigInt(0)];
     }
-    return ellipticCurve.sign(keyPair, BigInt(messageHash).toString(16)).map(BigInt);
+    const signature = ec.starkCurve.sign(BigInt(messageHash).toString(16), privateKey);
+    return [signature.r, signature.s];
 }
 
 /**
@@ -127,13 +109,9 @@ function ensureArtifact(fileName: string, artifactsTargetPath: string, artifactS
  * @returns an object with public, private key and key pair
  */
 export function generateKeys(providedPrivateKey?: string): KeysType {
-    const starkPrivateKey = providedPrivateKey
-        ? number.toBN(providedPrivateKey.replace(/^0x/, ""), 16)
-        : generateRandomStarkPrivateKey();
-    const keyPair = ellipticCurve.getKeyPair(starkPrivateKey);
-    const publicKey = ellipticCurve.getStarkKey(keyPair);
-    const privateKey = "0x" + starkPrivateKey.toString(16);
-    return { publicKey, privateKey, keyPair };
+    const privateKey = providedPrivateKey ?? stark.randomAddress();
+    const publicKey = ec.starkCurve.getStarkKey(privateKey);
+    return { publicKey, privateKey };
 }
 
 const INITIAL_NONCE = "0x0";

--- a/src/devnet-utils.ts
+++ b/src/devnet-utils.ts
@@ -1,12 +1,11 @@
 import axios, { AxiosResponse, Method } from "axios";
+import { Devnet, HardhatRuntimeEnvironment } from "hardhat/types";
+import { selector } from "starknet";
 
 import { StarknetPluginError } from "./starknet-plugin-error";
-import { Devnet, HardhatRuntimeEnvironment } from "hardhat/types";
-
 import { MintResponse, L2ToL1Message } from "./starknet-types";
-import { hash } from "starknet";
-import { numericToHexString } from "./utils";
 import { Numeric } from "./types";
+import { numericToHexString } from "./utils";
 
 interface L1ToL2Message {
     address: string;
@@ -147,7 +146,7 @@ Make sure you really want to interact with Devnet and that it is running and ava
     ) {
         const body = {
             l2_contract_address: l2ContractAddress,
-            entry_point_selector: hash.getSelectorFromName(functionName),
+            entry_point_selector: selector.getSelectorFromName(functionName),
             l1_contract_address: l1ContractAddress,
             payload: payload.map((item) => numericToHexString(item)),
             nonce: numericToHexString(nonce),

--- a/src/extend-utils.ts
+++ b/src/extend-utils.ts
@@ -1,4 +1,4 @@
-import { Block, HardhatRuntimeEnvironment } from "hardhat/types";
+import { Block, HardhatRuntimeEnvironment, Transaction } from "hardhat/types";
 import path from "path";
 import { uint256 } from "starknet";
 
@@ -10,7 +10,7 @@ import {
     SHORT_STRING_MAX_CHARACTERS
 } from "./constants";
 import { StarknetPluginError } from "./starknet-plugin-error";
-import { Transaction, TransactionReceipt, TransactionTrace } from "./starknet-types";
+import { TransactionReceipt, TransactionTrace } from "./starknet-types";
 import { BlockIdentifier, NonceQueryOptions, StarknetContractFactory } from "./types";
 import { checkArtifactExists, findPath } from "./utils";
 

--- a/src/extend-utils.ts
+++ b/src/extend-utils.ts
@@ -194,7 +194,5 @@ export async function getBalanceUtil(
     const ethContract = contractFactory.getContractAt(ETH_ADDRESS);
 
     const result = await ethContract.call("balanceOf", { account: address });
-    const convertedBalance = uint256.uint256ToBN(result.balance).toString();
-
-    return BigInt(convertedBalance);
+    return uint256.uint256ToBN(result.balance);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,7 @@ import { DevnetUtils } from "./devnet-utils";
 import { ExternalServer } from "./external-server";
 import { ArgentAccount, OpenZeppelinAccount } from "./account";
 import { AmarnaDocker } from "./external-server/docker-amarna";
+import { StarknetLegacyWrapper } from "./starknet-js-wrapper";
 
 exitHook(() => {
     ExternalServer.cleanAll();
@@ -150,11 +151,8 @@ extendConfig((config: HardhatConfig) => {
 
 // set network as specified in userConfig
 extendConfig((config: HardhatConfig, userConfig: Readonly<HardhatUserConfig>) => {
-    if (userConfig.starknet && userConfig.starknet.network) {
-        config.starknet.network = userConfig.starknet.network;
-    } else {
-        config.starknet.network = DEFAULT_STARKNET_NETWORK;
-    }
+    config.starknet.network = userConfig.starknet?.network || DEFAULT_STARKNET_NETWORK;
+
     const networkConfig = getNetwork(
         config.starknet.network,
         config.networks,
@@ -174,6 +172,8 @@ function setVenvWrapper(hre: HardhatRuntimeEnvironment, venvPath: string) {
 
 // add venv wrapper or docker wrapper of starknet
 extendEnvironment((hre) => {
+    hre.starknetJs = new StarknetLegacyWrapper(hre.config.starknet.networkConfig);
+
     const venvPath = hre.config.starknet.venv;
     if (venvPath) {
         setVenvWrapper(hre, venvPath);

--- a/src/starknet-js-wrapper.ts
+++ b/src/starknet-js-wrapper.ts
@@ -1,0 +1,118 @@
+import { ProcessResult } from "@nomiclabs/hardhat-docker";
+import { promises as fsp } from "fs";
+import { NetworkConfig } from "hardhat/types/config";
+import {
+    BigNumberish,
+    BlockIdentifier,
+    json,
+    provider as providerUtil,
+    SequencerProvider
+} from "starknet";
+
+export class StarknetJsWrapper {
+    public provider: SequencerProvider;
+
+    constructor(networkConfig: NetworkConfig) {
+        this.setProvider(networkConfig);
+    }
+
+    public setProvider(networkConfig: NetworkConfig) {
+        this.provider = new SequencerProvider({
+            baseUrl: networkConfig.url
+        });
+    }
+}
+
+/**
+ * StarknetLegacyWrapper is meant to facilitate the discontinuation of the Starknet CLI usage within StarknetWrapper
+ */
+export class StarknetLegacyWrapper extends StarknetJsWrapper {
+    private async readContract(contractPath: string) {
+        return json.parse((await fsp.readFile(contractPath)).toString("ascii"));
+    }
+
+    private stringifyResponse(r: unknown) {
+        return typeof r !== "string"
+            ? `${json.stringify(r, undefined, "\n").replace(/\n+/g, "\n")}\n`
+            : r;
+    }
+
+    private generateProcessResult(
+        statusCode: number,
+        stdout: string,
+        stderr: string
+    ): ProcessResult {
+        return {
+            statusCode,
+            stdout,
+            stderr
+        } as unknown as ProcessResult;
+    }
+
+    private async wrapProcessResult(p: Promise<unknown>): Promise<ProcessResult> {
+        return p
+            .then((a) => this.generateProcessResult(0, this.stringifyResponse(a), ""))
+            .catch((e) => this.generateProcessResult(1, "", this.stringifyResponse(e)));
+    }
+
+    public async declare(
+        contractPath: string,
+        senderAddress: string,
+        signature: string[],
+        nonce: string,
+        maxFee: string
+    ): Promise<ProcessResult> {
+        const contractJson = await this.readContract(contractPath);
+        const contract = providerUtil.parseContract(contractJson);
+
+        return this.wrapProcessResult(
+            this.provider
+                .declareContract(
+                    {
+                        contract,
+                        senderAddress,
+                        signature
+                    },
+                    {
+                        nonce,
+                        maxFee
+                    }
+                )
+                .then(
+                    ({ class_hash, transaction_hash }) =>
+                        "DeprecatedDeclare transaction was sent.\n" +
+                        `Contract class hash: ${class_hash}\n` +
+                        `Transaction hash: ${transaction_hash}\n`
+                )
+        );
+    }
+
+    public async getTxStatus(txHash: BigNumberish): Promise<ProcessResult> {
+        return this.wrapProcessResult(this.provider.getTransactionStatus(txHash));
+    }
+
+    public async getTransactionTrace(txHash: BigNumberish): Promise<ProcessResult> {
+        return this.wrapProcessResult(this.provider.getTransactionTrace(txHash));
+    }
+
+    public async getTransactionReceipt(txHash: BigNumberish): Promise<ProcessResult> {
+        return this.wrapProcessResult(this.provider.getTransactionReceipt(txHash));
+    }
+
+    public async getTransaction(txHash: BigNumberish): Promise<ProcessResult> {
+        return this.wrapProcessResult(this.provider.getTransaction(txHash));
+    }
+
+    public async getBlock(blockIdentifier?: BlockIdentifier): Promise<ProcessResult> {
+        return this.wrapProcessResult(this.provider.getBlock(blockIdentifier));
+    }
+
+    public async getNonce(
+        address: string,
+        blockIdentifier?: BlockIdentifier
+    ): Promise<ProcessResult> {
+        return this.wrapProcessResult(
+            this.provider.getNonceForAddress(address, blockIdentifier).then(BigInt)
+        );
+    }
+}

--- a/src/starknet-types.ts
+++ b/src/starknet-types.ts
@@ -131,20 +131,6 @@ export interface TransactionTrace {
     fee_transfer_invocation?: FunctionInvocation;
 }
 
-export interface Block {
-    block_hash: string;
-    parent_block_hash: string;
-    block_number: number;
-    gas_price: string;
-    sequencer_address: string;
-    state_root: string;
-    status: string;
-    timestamp: number;
-    transaction_receipts: TransactionReceipt[];
-    transactions: TransactionData[];
-    starknet_version: string;
-}
-
 export interface MintResponse {
     new_balance: number;
     unit: string;

--- a/src/starknet-wrappers.ts
+++ b/src/starknet-wrappers.ts
@@ -2,7 +2,8 @@ import { Image, ProcessResult } from "@nomiclabs/hardhat-docker";
 import axios from "axios";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import path from "path";
-import { hash, number } from "starknet";
+import { num, selector } from "starknet";
+
 import { DockerCairo1Compiler, exec } from "./cairo1-compiler";
 import {
     CAIRO1_COMPILE_BIN,
@@ -458,8 +459,8 @@ export abstract class StarknetWrapper {
         const body = {
             from_address: fromAddress,
             to_address: toAddress,
-            entry_point_selector: hash.getSelectorFromName(functionName),
-            payload: inputs.map((item) => number.toHex(number.toBN(item)))
+            entry_point_selector: selector.getSelectorFromName(functionName),
+            payload: inputs.map((item) => num.toHex(BigInt(item)))
         };
 
         const response = await axios.post(

--- a/src/task-actions.ts
+++ b/src/task-actions.ts
@@ -573,6 +573,8 @@ function setRuntimeNetwork(args: TaskArguments, hre: HardhatRuntimeEnvironment) 
     hre.starknet.network = networkName;
     hre.starknet.networkConfig = networkConfig;
 
+    hre.starknetJs.setProvider(hre.starknet.networkConfig);
+
     console.log(`Using network ${hre.starknet.network} at ${hre.starknet.networkConfig.url}`);
 }
 

--- a/src/type-extensions.ts
+++ b/src/type-extensions.ts
@@ -1,13 +1,16 @@
 import "hardhat/types/config";
 import "hardhat/types/runtime";
-import { StarknetContract, StarknetContractFactory, StringMap } from "./types";
-import { StarknetWrapper } from "./starknet-wrappers";
-import * as DevnetTypes from "./types/devnet";
-import * as StarknetTypes from "./types/starknet";
+import { GetBlockResponse } from "starknet";
+
 import { Account } from "./account";
-import { Transaction, TransactionReceipt, Block, TransactionTrace } from "./starknet-types";
 import { StarknetChainId } from "./constants";
 import { AmarnaDocker } from "./external-server/docker-amarna";
+import { Transaction, TransactionReceipt, TransactionTrace } from "./starknet-types";
+import { StarknetLegacyWrapper } from "./starknet-js-wrapper";
+import { StarknetWrapper } from "./starknet-wrappers";
+import { StarknetContract, StarknetContractFactory, StringMap } from "./types";
+import * as DevnetTypes from "./types/devnet";
+import * as StarknetTypes from "./types/starknet";
 
 declare module "hardhat/types/config" {
     export interface ProjectPathsUserConfig {
@@ -79,7 +82,7 @@ type AccountType = Account;
 type TransactionReceiptType = TransactionReceipt;
 type TransactionTraceType = TransactionTrace;
 type TransactionType = Transaction;
-type BlockType = Block;
+type BlockType = GetBlockResponse;
 
 declare module "hardhat/types/runtime" {
     export interface Devnet extends DevnetTypes.Devnet {}
@@ -87,6 +90,7 @@ declare module "hardhat/types/runtime" {
         starknetWrapper: StarknetWrapper;
         amarnaDocker: AmarnaDocker;
         starknet: StarknetTypes.Starknet;
+        starknetJs: StarknetLegacyWrapper;
     }
 
     type StarknetContract = StarknetContractType;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,8 +1,8 @@
-import * as fs from "fs";
+import fs from "fs";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
-import { selector } from "starknet";
+import { SequencerProvider, selector } from "starknet";
 
-import { adaptInputUtil, adaptOutputUtil } from "../adapt";
+import { adaptInputUtil, adaptOutputUtil, formatFelt } from "../adapt";
 import {
     CHECK_STATUS_RECOVER_TIMEOUT,
     QUERY_VERSION,
@@ -525,6 +525,10 @@ export class StarknetContract {
         return;
     }
 
+    get provider(): SequencerProvider {
+        return this.hre.starknetJs.provider;
+    }
+
     /**
      * Set a custom abi and abi path to the contract
      * @param implementation the contract factory of the implementation to be set
@@ -532,50 +536,6 @@ export class StarknetContract {
     setImplementation(implementation: StarknetContractFactory): void {
         this.abi = implementation.abi;
         this.abiPath = implementation.abiPath;
-    }
-
-    private async interact(
-        choice: InteractChoice,
-        functionName: string,
-        args?: StringMap,
-        options: InteractOptions = {}
-    ) {
-        if (!this.address) {
-            throw new StarknetPluginError("Contract not deployed");
-        }
-
-        const adaptedInput = options.rawInput
-            ? <string[]>args
-            : this.adaptInput(functionName, args);
-
-        // omit cairo 1.0 ABIs as it's not supported by the cairo-lang parser.
-        const abi =
-            this.abiPath && !fs.readFileSync(this.abiPath, "utf8").includes("core::")
-                ? this.abiPath
-                : undefined;
-        const executed = await this.hre.starknetWrapper.interact({
-            choice,
-            address: this.address,
-            abi,
-            functionName: functionName,
-            inputs: adaptedInput,
-            signature: handleSignature(options.signature),
-            blockNumber: "blockNumber" in options ? options.blockNumber : undefined,
-            maxFee: options.maxFee?.toString(),
-            nonce: options.nonce?.toString()
-        });
-
-        if (executed.statusCode) {
-            const msg =
-                `Could not perform ${choice.internalCommand} on ${functionName}.\n` +
-                executed.stderr.toString() +
-                "\n" +
-                "Make sure to `invoke` and `estimateFee` through account, and `call` directly through contract.";
-            const replacedMsg = adaptLog(msg);
-            throw new StarknetPluginError(replacedMsg);
-        }
-
-        return executed;
     }
 
     /**
@@ -591,19 +551,40 @@ export class StarknetContract {
         args?: StringMap,
         options: InvokeOptions = {}
     ): Promise<InvokeResponse> {
-        const executed = await this.interact(InteractChoice.INVOKE, functionName, args, options);
-        const txHash = extractTxHash(executed.stdout.toString());
+        try {
+            const adaptedInput = options.rawInput
+                ? <string[]>args
+                : this.adaptInput(functionName, args);
 
-        return new Promise<string>((resolve, reject) => {
-            iterativelyCheckStatus(
-                txHash,
-                this.hre.starknetWrapper,
-                () => resolve(txHash),
-                (error) => {
-                    reject(new StarknetPluginError(`Invoke transaction ${txHash}: ${error}`));
+            const { transaction_hash: txHash } = await this.provider.invokeFunction(
+                {
+                    contractAddress: this.address,
+                    entrypoint: functionName,
+                    calldata: adaptedInput,
+                    signature: options.signature.map(String)
+                },
+                {
+                    nonce: options.nonce ?? (await this.provider.getNonceForAddress(this.address)),
+                    maxFee: options.maxFee,
+                    version: InteractChoice.INVOKE.transactionVersion
                 }
             );
-        });
+
+            return new Promise<string>((resolve, reject) => {
+                iterativelyCheckStatus(
+                    txHash,
+                    this.hre.starknetWrapper,
+                    () => resolve(txHash),
+                    (error) => {
+                        reject(new StarknetPluginError(`Invoke transaction ${txHash}: ${error}`));
+                    }
+                );
+            });
+        } catch (error) {
+            if (!(error instanceof Error)) throw error;
+
+            throw new StarknetPluginError(error.message, error);
+        }
     }
 
     /**
@@ -638,17 +619,32 @@ export class StarknetContract {
         args?: StringMap,
         options: CallOptions = {}
     ): Promise<StringMap> {
-        const adaptedOptions = defaultToPendingBlock(options);
-        const executed = await this.interact(
-            InteractChoice.CALL,
-            functionName,
-            args,
-            adaptedOptions
-        );
-        if (options.rawOutput) {
-            return { response: executed.stdout.toString().split(" ") };
+        try {
+            const adaptedOptions = defaultToPendingBlock(options);
+            const adaptedInput = adaptedOptions.rawInput
+                ? <string[]>args
+                : this.adaptInput(functionName, args);
+
+            const { result } = await this.provider.callContract(
+                {
+                    contractAddress: this.address,
+                    entrypoint: functionName,
+                    calldata: adaptedInput
+                },
+                adaptedOptions.blockNumber
+            );
+            // align to legacy stdout output
+            const response = result.map(formatFelt).join(" ");
+
+            if (options.rawOutput) {
+                return { response };
+            }
+            return this.adaptOutput(functionName, response);
+        } catch (error) {
+            if (!(error instanceof Error)) throw error;
+
+            throw new StarknetPluginError(error.message, error);
         }
-        return this.adaptOutput(functionName, executed.stdout.toString());
     }
 
     /**
@@ -689,14 +685,33 @@ export class StarknetContract {
         args?: StringMap,
         options: EstimateFeeOptions = {}
     ): Promise<starknet.FeeEstimation> {
-        const adaptedOptions = defaultToPendingBlock(options);
-        const executed = await this.interact(
-            InteractChoice.ESTIMATE_FEE,
-            functionName,
-            args,
-            adaptedOptions
-        );
-        return parseFeeEstimation(executed.stdout.toString());
+        try {
+            const { nonce, maxFee, signature } = defaultToPendingBlock(options);
+            const result = await this.provider.getInvokeEstimateFee(
+                {
+                    contractAddress: this.address,
+                    calldata: args,
+                    signature: signature.map(String)
+                },
+                {
+                    nonce: nonce ?? (await this.provider.getNonceForAddress(this.address)),
+                    maxFee: maxFee,
+                    version: InteractChoice.ESTIMATE_FEE.transactionVersion
+                },
+                options.blockNumber
+            );
+
+            return {
+                amount: result.overall_fee,
+                unit: "wei",
+                gas_price: result.gas_price,
+                gas_usage: result.gas_consumed
+            };
+        } catch (error) {
+            if (!(error instanceof Error)) throw error;
+
+            throw new StarknetPluginError(error.message, error);
+        }
     }
 
     /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,8 @@
 import * as fs from "fs";
-import * as starknet from "../starknet-types";
-import { StarknetPluginError } from "../starknet-plugin-error";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { selector } from "starknet";
+
+import { adaptInputUtil, adaptOutputUtil } from "../adapt";
 import {
     CHECK_STATUS_RECOVER_TIMEOUT,
     QUERY_VERSION,
@@ -8,11 +10,10 @@ import {
     HEXADECIMAL_REGEX,
     CHECK_STATUS_TIMEOUT
 } from "../constants";
-import { adaptLog, copyWithBigint, findConstructor, formatSpaces, sleep, warn } from "../utils";
-import { adaptInputUtil, adaptOutputUtil } from "../adapt";
-import { HardhatRuntimeEnvironment } from "hardhat/types";
-import { hash } from "starknet";
+import { StarknetPluginError } from "../starknet-plugin-error";
+import * as starknet from "../starknet-types";
 import { StarknetWrapper } from "../starknet-wrappers";
+import { adaptLog, copyWithBigint, findConstructor, formatSpaces, sleep, warn } from "../utils";
 
 /**
  * According to: https://starknet.io/docs/hello_starknet/intro.html#interact-with-the-contract
@@ -246,7 +247,7 @@ function extractEventSpecifications(abi: starknet.Abi) {
     for (const abiEntryName in abi) {
         if (abi[abiEntryName].type === "event") {
             const event = <starknet.EventSpecification>abi[abiEntryName];
-            const encodedEventName = hash.getSelectorFromName(event.name);
+            const encodedEventName = selector.getSelectorFromName(event.name);
             events[encodedEventName] = event;
         }
     }
@@ -400,9 +401,9 @@ export class StarknetContractFactory {
 
         // Can be simplified once starkware fixes multiple constructor issue.
         // Precomputed selector can be used if only 'constructor' name allowed
-        const selector = constructors[0].selector;
+        const constructorSelector = constructors[0].selector;
         return (abiEntry: starknet.AbiEntry): boolean => {
-            return hash.getSelectorFromName(abiEntry.name) === selector;
+            return selector.getSelectorFromName(abiEntry.name) === constructorSelector;
         };
     }
 

--- a/src/types/starknet.ts
+++ b/src/types/starknet.ts
@@ -1,9 +1,9 @@
+import { Block, HardhatNetworkConfig, NetworkConfig, Transaction } from "hardhat/types";
+
 import { BlockIdentifier, NonceQueryOptions, StarknetContractFactory } from ".";
 import { Devnet } from "./devnet";
-import { Transaction, TransactionReceipt, Block, TransactionTrace } from "../starknet-types";
-import {} from "../account";
-import { HardhatNetworkConfig, NetworkConfig } from "hardhat/types/config";
 import { ArgentAccount, OpenZeppelinAccount } from "../account";
+import { TransactionReceipt, TransactionTrace } from "../starknet-types";
 
 export interface Starknet {
     /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,7 +10,7 @@ import {
     VmLang
 } from "hardhat/types";
 import path from "path";
-import { json, stark, CompiledContract } from "starknet";
+import { json, stark, LegacyCompiledContract } from "starknet";
 
 import { handleInternalContractArtifacts } from "./account-utils";
 import {
@@ -306,7 +306,7 @@ export class UDC {
 export function readContract(contractPath: string) {
     const parsedContract = json.parse(
         fs.readFileSync(contractPath).toString("ascii")
-    ) as CompiledContract;
+    ) as LegacyCompiledContract;
     return {
         ...parsedContract,
         program: stark.compressProgram(parsedContract.program)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "allowJs": true,
-        "target": "es2016",
+        "target": "es2020",
         "sourceMap": true,
         "esModuleInterop": true,
         "strict": true,

--- a/www/docs/dev.md
+++ b/www/docs/dev.md
@@ -127,9 +127,11 @@ Change the version in `hardhat.config.ts`. Recompile the contracts (only importa
 
 ### Wrapper
 
-This plugin is a wrapper around Starknet CLI (tool installed with cairo-lang). E.g. when you do `hardhat starknet-compile-deprecated` in a shell or `contractFactory.deploy()` in a Hardhat JS/TS script, you are making a subprocess that executes Starknet CLI's `starknet deploy`.
+This plugin was created as a wrapper for Starknet CLI (tool installed with cairo-lang) along with some compilation and hashing utilities. E.g. running `hardhat starknet-compile-deprecated` in a shell would create a subprocess that uses the corresponding compilation utility, while running `contractFactory.deploy()` in a Hardhat JS/TS script would create a subprocess that executes Starknet CLI's `starknet deploy`.
 
-There are two wrappers around Starknet CLI. They are defined in [starknet-wrapper.ts](https://github.com/0xSpaceShard/starknet-hardhat-plugin/blob/master/src/starknet-wrappers.ts) and both rely on a [proxy server](https://github.com/0xSpaceShard/starknet-hardhat-plugin/blob/master/src/starknet_cli_wrapper.py) that imports `main` methods of `starknet` and `starknet-compile-deprecated` and uses them to execute commands (this is a speedup since a subprocess importing the whole Starknet doesn't have to be spawned for each request).
+With the Starknet CLI deprecation for Starknet v0.13.0 the plugin's usages of the CLI core commands were replaced with near analogs utilizing `starknet.js`. For the earlier `contractFactory.deploy()` example the plugin no longer executes Starknet CLI's `starknet deploy` itself, instead it executes the equivalent HTTP requests that the CLI command would do internally.
+
+Two wrapper implementations are used that are defined in [starknet-wrapper.ts](https://github.com/0xSpaceShard/starknet-hardhat-plugin/blob/master/src/starknet-wrappers.ts). Both rely on a [proxy server](https://github.com/0xSpaceShard/starknet-hardhat-plugin/blob/master/src/starknet_cli_wrapper.py) that imports `main` methods of `starknet` and `starknet-compile-deprecated` and uses them to execute commands (this is a speedup since a subprocess importing the whole Starknet doesn't have to be spawned for each request).
 
 -   Docker wrapper:
     -   runs Starknet CLI in a Docker container


### PR DESCRIPTION
## Usage related changes

<!-- How the changes from this PR affect users. -->

- For happiest path scenarios the hope is that users should not be affected
- Minor API changes for ancillary functionalities and functions, most notably a truncated response for the `getBlock` method
- Some internally re-thrown errors might be different due to differences in the underlying tool used

## Development related changes

- Starknet CLI internal usage removal in favour of starknet.js (`~5.17.0`) utilization
- new `starknetJs` property available for the runtime environment
- Resolves: #395 
- Resolves: #140 

## Checklist:

-   [x] Formatted the code
-   [x] No linter errors + tried to avoid introducing linter warnings
-   [x] Performed a self-review of the code
-   [x] Rebased to the last commit of the target branch (or merged it into my branch)
-   [x] Documented the changes
-   [ ] Updated the `test` directory (with a test case consisting of `network.json`, `hardhat.config.ts`, `check.ts`)
-   [x] Linked issues which this PR resolves
-   [x] Created a PR to the `plugin` branch of [`starknet-hardhat-example`](https://github.com/0xSpaceShard/starknet-hardhat-example):
    -   https://github.com/0xSpaceShard/starknet-hardhat-example/pull/123
    -   [x] Modified `test.sh` to use my example repo branch
    -   [ ] Restored `test.sh` to to use the original branch (after the example repo PR has been merged)
